### PR TITLE
Fix views.sql filename reference in git_integration_deployment.md

### DIFF
--- a/git_integration_deployment.md
+++ b/git_integration_deployment.md
@@ -59,10 +59,10 @@ You only need to do below steps one time.
 The initial application data will be automatically populated, if not existing, in the SQL Database when you start the backend application. So you do not need to do any extra steps to ingest data. But for the Power BI reporting layer, we need to add some extra views.
 
 **Add views to the SQL Analytics endpoint**
-- Go to the **SQL analytics** endpoint of your **agentic_lake**:
+- Go to the **SQL analytics** endpoint of your **agentic_lake** and open a **new query window**:
 
     ![lakehouse](assets/lakehouse.png)
-- Go to **Data_Ingest** folder and run all 3 queries that you see in file **views.sql**:
+- In the **GitHub repo**, open **`Data_Ingest/create_views.sql`**, copy all the code, paste it into your lakehouse query window, and run to create **3 new views**:
 
     ![lakehouse](assets/views.png)
 


### PR DESCRIPTION
## Summary

Addresses the two concerns from #38: the SQL file reference in `git_integration_deployment.md` pointed at `views.sql`, which does not exist in `Data_Ingest/`, and the surrounding instructions did not explain how to actually run the queries.

## Why this matters

The current Step 4 text tells readers to "go to Data_Ingest folder and run all 3 queries that you see in file **views.sql**." The actual file on disk is `Data_Ingest/create_views.sql` (`ls Data_Ingest/` shows `create_views.sql`, `ingest_data.sql`, and `agentic_data_tables_setup_day0.sql` - no `views.sql`). First-time readers who follow the instructions literally will not find the file. The [wording suggestion in #38](https://github.com/Azure-Samples/agentic-app-with-fabric/issues/38) (from @jehayes) is the basis for the rewritten bullets.

## Changes

`git_integration_deployment.md` lines 62 and 65, two bullets in the "Add views to the SQL Analytics endpoint" block.

Before:
```
- Go to the **SQL analytics** endpoint of your **agentic_lake**:
- Go to **Data_Ingest** folder and run all 3 queries that you see in file **views.sql**:
```

After:
```
- Go to the **SQL analytics** endpoint of your **agentic_lake** and open a **new query window**:
- In the **GitHub repo**, open **`Data_Ingest/create_views.sql`**, copy all the code, paste it into your lakehouse query window, and run to create **3 new views**:
```

The two image references (`assets/lakehouse.png`, `assets/views.png`) are unchanged and stay in the same relative positions. No other files touched.

## Testing

- `ls Data_Ingest/` confirms `create_views.sql` exists; no `views.sql`
- `grep -n "CREATE VIEW" Data_Ingest/create_views.sql` returns 3 views (`session_duration_date`, `ContentIssues`, `UserAsks`), matching the "3 new views" claim in the instructions
- `git diff` shows only `git_integration_deployment.md` modified, 2 insertions, 2 deletions

Fixes #38
