### PR TITLE
Add per-trace token cost tracking and Cost Insights card

### DIFF
--- a/Fabric_artifacts/agentic_app_db.SQLDatabase/dbo/Tables/chat_history.sql
+++ b/Fabric_artifacts/agentic_app_db.SQLDatabase/dbo/Tables/chat_history.sql
@@ -21,6 +21,7 @@ CREATE TABLE [dbo].[chat_history] (
     [finish_reason]          VARCHAR (255)  NULL,
     [response_time_ms]       INT            NULL,
     [trace_end]              DATETIME2 (7)  DEFAULT (getdate()) NULL,
+    [estimated_cost_usd]     DECIMAL (10, 6) NULL,
     PRIMARY KEY CLUSTERED ([message_id] ASC)
 );
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ An interactive banking demo that shows how databases power **OLTP**, **OLAP**, a
 - **AI Agents** — multi-agent LangGraph system with a coordinator, support, account, Fabric Data Agent (optional), and visualization agent
 - **Generative UI** — agents create personalized interactive visualizations on the fly
 - **Real-time Monitoring** — app usage and content safety data streamed to Fabric Eventhouse via Eventstream
+- **Cost insights** - per-agent token cost breakdown in the analytics tab; override model pricing via .env
 
 ---
 

--- a/backend/agent_analytics.py
+++ b/backend/agent_analytics.py
@@ -34,7 +34,8 @@ from chat_data_model import (
     ToolDefinition, ChatHistoryManager, AgentDefinition, AgentTrace,
     handle_chat_sessions,
     clear_chat_history, clear_session_data, initialize_tool_definitions,
-    initialize_agent_definitions
+    initialize_agent_definitions,
+    ensure_chat_history_columns,
 )
 from cost_analytics import cost_analytics_bp
 import cosmos_chat_model
@@ -257,6 +258,7 @@ def initialize_analytics_app():
     """Initialize analytics app when called from combined launcher."""
     with app.app_context():
         db.create_all()
+        ensure_chat_history_columns(db)
         initialize_tool_definitions()
         initialize_agent_definitions()
         print("[Analytics Service] Database tables initialized")

--- a/backend/agent_analytics.py
+++ b/backend/agent_analytics.py
@@ -36,7 +36,10 @@ from chat_data_model import (
     clear_chat_history, clear_session_data, initialize_tool_definitions,
     initialize_agent_definitions
 )
+from cost_analytics import cost_analytics_bp
 import cosmos_chat_model
+
+app.register_blueprint(cost_analytics_bp)
 
 # Chat History API Routes
 @app.route('/api/chat/sessions', methods=['GET', 'POST'])

--- a/backend/analytics_service.py
+++ b/backend/analytics_service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Dict, Any
 
 from shared.utils import _serialize_messages, _to_json_primitive
+from shared.pricing import estimate_cost
 from langchain_core.messages import BaseMessage
 import os
 from dotenv import load_dotenv
@@ -150,6 +151,11 @@ def log_chat_trace(
                             total_tokens=msg.get("response_metadata", {}).get("token_usage", {}).get('total_tokens'),
                             completion_tokens=msg.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
                             prompt_tokens=msg.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                            estimated_cost_usd=estimate_cost(
+                                msg.get("response_metadata", {}).get('model_name'),
+                                msg.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                                msg.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
+                            ),
                             tool_input=tool_call.get('function', {}).get("arguments"),
                             model_name=msg.get("response_metadata", {}).get('model_name'),
                             finish_reason=msg.get("response_metadata", {}).get("finish_reason"),
@@ -178,6 +184,11 @@ def log_chat_trace(
                         total_tokens=msg.get("response_metadata", {}).get("token_usage", {}).get('total_tokens'),
                         completion_tokens=msg.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
                         prompt_tokens=msg.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                        estimated_cost_usd=estimate_cost(
+                            msg.get("response_metadata", {}).get('model_name'),
+                            msg.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                            msg.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
+                        ),
                         model_name=msg.get("response_metadata", {}).get('model_name'),
                         finish_reason=msg.get("response_metadata", {}).get("finish_reason"),
                         response_time_ms=trace_duration_ms,

--- a/backend/banking_app.py
+++ b/backend/banking_app.py
@@ -24,7 +24,7 @@ from langgraph.store.memory import InMemoryStore
 from shared.connection_manager import sqlalchemy_connection_creator
 from tools.database_query import query_database
 from analytics_service import get_chat_history_for_session
-from chat_data_model import init_chat_db
+from chat_data_model import init_chat_db, ensure_chat_history_columns
 
 from chat_data_model import init_chat_db
 from ai_widget_model import init_ai_widget_db
@@ -962,6 +962,7 @@ def initialize_banking_app():
     """Initialize banking app when called from combined launcher."""
     with app.app_context():
         db.create_all()
+        ensure_chat_history_columns(db)
         print("[Banking Service] Database tables initialized")
 
 # ---------- Frontend (React) routes ----------

--- a/backend/chat_data_model.py
+++ b/backend/chat_data_model.py
@@ -790,6 +790,50 @@ def init_chat_db(database):
     globals()['ChatHistoryManager'] = ChatHistoryManager
     globals()['AgentTrace'] = AgentTrace
 
+
+def ensure_chat_history_columns(database):
+    """Add chat_history columns that exist in the ORM model but may be missing
+    from an older deployed schema. Safe to call on every startup: each ALTER is
+    guarded by an existence check and any error is logged without raising.
+
+    Currently covers:
+      - ``estimated_cost_usd DECIMAL(10, 6)`` (added 2026-04; previously cost
+        was computed on the fly at query time).
+    """
+    # Column definitions: (column_name, SQL Server type, SQLite fallback type).
+    columns = [
+        ("estimated_cost_usd", "DECIMAL(10, 6) NULL", "NUMERIC(10, 6) NULL"),
+    ]
+
+    try:
+        from sqlalchemy import inspect
+        engine = database.engine
+        inspector = inspect(engine)
+        existing = {col["name"] for col in inspector.get_columns("chat_history")}
+    except Exception as e:
+        print(f"[chat_data_model.ensure_chat_history_columns] inspector failed: {e}")
+        return
+
+    dialect = engine.dialect.name.lower() if hasattr(engine, "dialect") else ""
+    for name, mssql_type, sqlite_type in columns:
+        if name in existing:
+            continue
+        col_type = sqlite_type if dialect == "sqlite" else mssql_type
+        try:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(
+                    f"ALTER TABLE chat_history ADD {name} {col_type}"
+                )
+            print(f"[chat_data_model] Added missing column chat_history.{name}")
+        except Exception as e:
+            # Non-fatal: the app still starts; the column is only used for the
+            # optional Cost Insights dashboard. Surface the error and move on.
+            print(
+                f"[chat_data_model.ensure_chat_history_columns] "
+                f"could not add chat_history.{name}: {e}"
+            )
+
+
 def handle_chat_sessions(request):
     """Handle chat sessions GET and POST requests"""
     user_id = get_user_id()  # In production, get from auth

--- a/backend/chat_data_model.py
+++ b/backend/chat_data_model.py
@@ -4,6 +4,7 @@ import os
 from flask import jsonify
 from shared.utils import _serialize_messages, _to_json_primitive
 from shared.utils import get_user_id
+from shared.pricing import estimate_cost
 
 # Global variables that will be set by the main app
 db = None
@@ -260,6 +261,7 @@ def init_chat_db(database):
         total_tokens = db.Column(db.Integer)
         completion_tokens = db.Column(db.Integer)
         prompt_tokens = db.Column(db.Integer)
+        estimated_cost_usd = db.Column(db.Numeric(10, 6))  # populated from pricing.estimate_cost; null if tokens or model unknown
 
         tool_id = db.Column(db.String(255))
         tool_name = db.Column(db.String(255))
@@ -517,6 +519,11 @@ def init_chat_db(database):
                 total_tokens=message.get("response_metadata", {}).get("token_usage", {}).get('total_tokens'),
                 completion_tokens=message.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
                 prompt_tokens=message.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                estimated_cost_usd=estimate_cost(
+                    message.get("response_metadata", {}).get('model_name'),
+                    message.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                    message.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
+                ),
                 model_name=message.get("response_metadata", {}).get('model_name'),
                 content_filter_results=message.get("response_metadata", {}).get("prompt_filter_results", [{}])[0].get("content_filter_results"),
                 finish_reason=message.get("response_metadata", {}).get("finish_reason"),
@@ -601,6 +608,11 @@ def init_chat_db(database):
                 total_tokens=message.get("response_metadata", {}).get("token_usage", {}).get('total_tokens'),
                 completion_tokens=message.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
                 prompt_tokens=message.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                estimated_cost_usd=estimate_cost(
+                    message.get("response_metadata", {}).get('model_name'),
+                    message.get("response_metadata", {}).get("token_usage", {}).get('prompt_tokens'),
+                    message.get("response_metadata", {}).get("token_usage", {}).get('completion_tokens'),
+                ),
                 tool_input=tool_input,
                 model_name=message.get("response_metadata", {}).get('model_name'),
                 content_filter_results=message.get("response_metadata", {}).get("prompt_filter_results", [{}])[0].get("content_filter_results"),

--- a/backend/cost_analytics.py
+++ b/backend/cost_analytics.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import and_, or_
+
+from chat_data_model import ChatHistory
+from shared.pricing import estimate_cost
+
+cost_analytics_bp = Blueprint("cost_analytics", __name__, url_prefix="/api/analytics")
+
+
+def _safe_float(value: Any) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return 0.0
+
+
+def _row_cost(row: ChatHistory) -> float:
+    if row.estimated_cost_usd is not None:
+        return _safe_float(row.estimated_cost_usd)
+    return estimate_cost(row.model_name, row.prompt_tokens, row.completion_tokens)
+
+
+def _usage_filter(query):
+    return query.filter(
+        or_(
+            ChatHistory.estimated_cost_usd.isnot(None),
+            and_(
+                ChatHistory.prompt_tokens.isnot(None),
+                ChatHistory.completion_tokens.isnot(None),
+            ),
+        )
+    )
+
+
+@cost_analytics_bp.route('/cost-summary', methods=['GET'])
+def get_cost_summary():
+    try:
+        days = int(request.args.get('days', 7))
+        if days <= 0:
+            days = 7
+    except Exception:
+        days = 7
+
+    cutoff = datetime.now() - timedelta(days=days)
+    rows: List[ChatHistory] = _usage_filter(
+        ChatHistory.query.filter(ChatHistory.trace_end >= cutoff)
+    ).all()
+
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    total_tokens = 0
+    total_cost_usd = 0.0
+    traces = set()
+    by_agent_cost: Dict[str, float] = {}
+    by_model_cost: Dict[str, float] = {}
+
+    for row in rows:
+        prompt_tokens = row.prompt_tokens or 0
+        completion_tokens = row.completion_tokens or 0
+        row_total_tokens = row.total_tokens if row.total_tokens is not None else (prompt_tokens + completion_tokens)
+        row_cost = _row_cost(row)
+
+        total_prompt_tokens += prompt_tokens
+        total_completion_tokens += completion_tokens
+        total_tokens += row_total_tokens
+        total_cost_usd += row_cost
+
+        if row.trace_id:
+            traces.add(row.trace_id)
+
+        agent_name = row.agent_name or "unknown"
+        by_agent_cost[agent_name] = by_agent_cost.get(agent_name, 0.0) + row_cost
+
+        model_name = row.model_name or "unknown"
+        by_model_cost[model_name] = by_model_cost.get(model_name, 0.0) + row_cost
+
+    conversations = len(traces)
+    avg_cost_per_conversation = (total_cost_usd / conversations) if conversations > 0 else 0.0
+
+    by_agent = []
+    for agent_name, cost in sorted(by_agent_cost.items(), key=lambda kv: kv[1], reverse=True):
+        percent = (cost / total_cost_usd * 100.0) if total_cost_usd > 0 else 0.0
+        by_agent.append({
+            "agent_name": agent_name,
+            "cost_usd": round(cost, 6),
+            "percent": round(percent, 2),
+        })
+
+    by_model = [
+        {"model_name": model_name, "cost_usd": round(cost, 6)}
+        for model_name, cost in sorted(by_model_cost.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+    return jsonify({
+        "total_prompt_tokens": total_prompt_tokens,
+        "total_completion_tokens": total_completion_tokens,
+        "total_tokens": total_tokens,
+        "total_cost_usd": round(total_cost_usd, 6),
+        "conversations": conversations,
+        "avg_cost_per_conversation": round(avg_cost_per_conversation, 6),
+        "by_agent": by_agent,
+        "by_model": by_model,
+    })
+
+
+@cost_analytics_bp.route('/trace/<trace_id>/cost', methods=['GET'])
+def get_trace_cost(trace_id: str):
+    rows: List[ChatHistory] = _usage_filter(
+        ChatHistory.query.filter_by(trace_id=trace_id)
+    ).order_by(ChatHistory.routing_step.asc(), ChatHistory.trace_end.asc()).all()
+
+    total_cost = 0.0
+    per_step = []
+
+    for row in rows:
+        prompt_tokens = row.prompt_tokens or 0
+        completion_tokens = row.completion_tokens or 0
+        row_total_tokens = row.total_tokens if row.total_tokens is not None else (prompt_tokens + completion_tokens)
+        cost = _row_cost(row)
+        total_cost += cost
+
+        per_step.append({
+            "agent_name": row.agent_name or "unknown",
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": row_total_tokens,
+            "cost_usd": round(cost, 6),
+            "model_name": row.model_name,
+        })
+
+    return jsonify({
+        "trace_id": trace_id,
+        "total_cost_usd": round(total_cost, 6),
+        "per_step": per_step,
+    })

--- a/backend/launcher.py
+++ b/backend/launcher.py
@@ -41,10 +41,12 @@ def run_combined_services():
         import agent_analytics
         
         # Initialize databases for both apps
+        from chat_data_model import ensure_chat_history_columns
         with banking_app.app.app_context():
             banking_app.db.create_all()
+            ensure_chat_history_columns(banking_app.db)
             print("✅ Banking database tables initialized")
-            
+
             # Run data ingestion
             try:
                 from init_data import check_and_ingest_data
@@ -52,9 +54,10 @@ def run_combined_services():
                 print("✅ Data initialization complete")
             except Exception as e:
                 print(f"⚠️ Data initialization warning: {e}")
-        
+
         with agent_analytics.app.app_context():
             agent_analytics.db.create_all()
+            ensure_chat_history_columns(agent_analytics.db)
             agent_analytics.initialize_tool_definitions()
             agent_analytics.initialize_agent_definitions()
             print("✅ Analytics database tables initialized")

--- a/backend/launcher_azure.py
+++ b/backend/launcher_azure.py
@@ -9,10 +9,12 @@ def create_combined_app():
     import agent_analytics
     
     # Initialize databases
+    from chat_data_model import ensure_chat_history_columns
     with banking_app.app.app_context():
         banking_app.db.create_all()
+        ensure_chat_history_columns(banking_app.db)
         print("✅ Banking database tables initialized")
-        
+
         # Run data ingestion
         try:
             from init_data import check_and_ingest_data
@@ -20,9 +22,10 @@ def create_combined_app():
             print("✅ Data initialization complete")
         except Exception as e:
             print(f"⚠️ Data initialization warning: {e}")
-    
+
     with agent_analytics.app.app_context():
         agent_analytics.db.create_all()
+        ensure_chat_history_columns(agent_analytics.db)
         agent_analytics.initialize_tool_definitions()
         agent_analytics.initialize_agent_definitions()
         print("✅ Analytics database tables initialized")

--- a/backend/shared/pricing.py
+++ b/backend/shared/pricing.py
@@ -1,0 +1,88 @@
+import json
+import os
+import re
+from typing import Any, Dict, Optional
+
+# Source: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/ (spot-checked 2026-04). Users can override via env AZURE_OPENAI_MODEL_PRICING_JSON.
+MODEL_PRICING_PER_1K_TOKENS: Dict[str, Dict[str, float]] = {
+    "gpt-4o": {"prompt": 0.005, "completion": 0.015},
+    "gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006},
+    "gpt-4-turbo": {"prompt": 0.01, "completion": 0.03},
+    "gpt-35-turbo": {"prompt": 0.0005, "completion": 0.0015},
+    "text-embedding-ada-002": {"prompt": 0.0001, "completion": 0.0},
+    "text-embedding-3-small": {"prompt": 0.00002, "completion": 0.0},
+    "text-embedding-3-large": {"prompt": 0.00013, "completion": 0.0},
+}
+
+_DATE_SUFFIX_RE = re.compile(r"-\d{4}-\d{2}-\d{2}$")
+
+
+def _normalize_model_name(model_name: Optional[str]) -> str:
+    if not model_name:
+        return ""
+    name = str(model_name).strip().lower()
+    return _DATE_SUFFIX_RE.sub("", name)
+
+
+def load_pricing_overrides() -> Dict[str, Dict[str, float]]:
+    raw = os.getenv("AZURE_OPENAI_MODEL_PRICING_JSON")
+    if not raw:
+        return {}
+
+    try:
+        parsed: Any = json.loads(raw)
+        if not isinstance(parsed, dict):
+            return {}
+
+        normalized: Dict[str, Dict[str, float]] = {}
+        for model_name, rates in parsed.items():
+            if not isinstance(model_name, str) or not isinstance(rates, dict):
+                continue
+
+            prompt = rates.get("prompt")
+            completion = rates.get("completion")
+            if prompt is None or completion is None:
+                continue
+
+            normalized[_normalize_model_name(model_name)] = {
+                "prompt": float(prompt),
+                "completion": float(completion),
+            }
+
+        return normalized
+    except Exception as e:
+        print(f"[pricing] Warning: failed to parse AZURE_OPENAI_MODEL_PRICING_JSON: {e}")
+        return {}
+
+
+def _get_pricing() -> Dict[str, Dict[str, float]]:
+    pricing = {k.lower(): dict(v) for k, v in MODEL_PRICING_PER_1K_TOKENS.items()}
+    pricing.update(load_pricing_overrides())
+    return pricing
+
+
+def estimate_cost(
+    model_name: Optional[str],
+    prompt_tokens: Optional[int],
+    completion_tokens: Optional[int],
+) -> float:
+    try:
+        if model_name is None or prompt_tokens is None or completion_tokens is None:
+            return 0.0
+        if prompt_tokens == 0 or completion_tokens == 0:
+            return 0.0
+        if prompt_tokens < 0 or completion_tokens < 0:
+            return 0.0
+
+        normalized_model = _normalize_model_name(model_name)
+        pricing = _get_pricing().get(normalized_model)
+        if not pricing:
+            return 0.0
+
+        prompt_rate = float(pricing.get("prompt", 0.0))
+        completion_rate = float(pricing.get("completion", 0.0))
+        prompt_cost = (float(prompt_tokens) / 1000.0) * prompt_rate
+        completion_cost = (float(completion_tokens) / 1000.0) * completion_rate
+        return float(prompt_cost + completion_cost)
+    except Exception:
+        return 0.0

--- a/backend/shared/pricing.py
+++ b/backend/shared/pricing.py
@@ -69,9 +69,9 @@ def estimate_cost(
     try:
         if model_name is None or prompt_tokens is None or completion_tokens is None:
             return 0.0
-        if prompt_tokens == 0 or completion_tokens == 0:
-            return 0.0
         if prompt_tokens < 0 or completion_tokens < 0:
+            return 0.0
+        if prompt_tokens == 0 and completion_tokens == 0:
             return 0.0
 
         normalized_model = _normalize_model_name(model_name)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.pop("AZURE_OPENAI_MODEL_PRICING_JSON", None)

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -62,3 +62,32 @@ def test_malformed_env_falls_back_to_defaults(monkeypatch):
     cost = module.estimate_cost("gpt-4o-mini", 1000, 500)
     expected = (1000 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["prompt"] + (500 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["completion"]
     assert abs(cost - expected) < 0.0001
+
+
+def test_embedding_prompt_only_usage_is_billed():
+    # text-embedding-ada-002 has prompt=0.0001, completion=0.0. A prompt-only
+    # call (completion_tokens=0) must return a non-zero cost.
+    module = _reload_pricing()
+    cost = module.estimate_cost("text-embedding-ada-002", 10_000, 0)
+    # 10_000 prompt tokens / 1000 * 0.0001 = 0.001
+    assert abs(cost - 0.001) < 1e-9
+
+
+def test_prompt_only_chat_call_is_billed():
+    # A chat call that produced a prompt but no completion (stream cutoff,
+    # content filter) still consumed prompt tokens and must be billed.
+    module = _reload_pricing()
+    cost = module.estimate_cost("gpt-4o-mini", 1000, 0)
+    expected = (1000 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["prompt"]
+    assert abs(cost - expected) < 1e-9
+
+
+def test_zero_on_both_sides_returns_zero():
+    module = _reload_pricing()
+    assert module.estimate_cost("gpt-4o-mini", 0, 0) == 0.0
+
+
+def test_negative_tokens_return_zero():
+    module = _reload_pricing()
+    assert module.estimate_cost("gpt-4o-mini", -1, 100) == 0.0
+    assert module.estimate_cost("gpt-4o-mini", 100, -1) == 0.0

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -1,0 +1,64 @@
+import importlib
+
+from shared import pricing
+
+
+def _reload_pricing():
+    return importlib.reload(pricing)
+
+
+def test_estimate_cost_known_model():
+    module = _reload_pricing()
+    cost = module.estimate_cost("gpt-4o-mini", 1000, 500)
+    expected = (1000 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["prompt"] + (500 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["completion"]
+    assert abs(cost - expected) < 0.0001
+
+
+def test_estimate_cost_unknown_model_returns_zero():
+    module = _reload_pricing()
+    assert module.estimate_cost("unknown-model", 1000, 500) == 0.0
+
+
+def test_estimate_cost_none_inputs_return_zero():
+    module = _reload_pricing()
+    assert module.estimate_cost(None, 1000, 500) == 0.0
+    assert module.estimate_cost("gpt-4o-mini", None, 500) == 0.0
+    assert module.estimate_cost("gpt-4o-mini", 1000, None) == 0.0
+
+
+def test_estimate_cost_case_insensitive_model_match():
+    module = _reload_pricing()
+    lower = module.estimate_cost("gpt-4o-mini", 1000, 500)
+    mixed = module.estimate_cost("GPT-4O-MINI", 1000, 500)
+    assert abs(lower - mixed) < 1e-9
+
+
+def test_estimate_cost_date_suffixed_model_name_maps_to_base():
+    module = _reload_pricing()
+    base = module.estimate_cost("gpt-4o-mini", 1000, 500)
+    suffixed = module.estimate_cost("gpt-4o-mini-2024-11-20", 1000, 500)
+    assert abs(base - suffixed) < 1e-9
+
+
+def test_env_override_merges_without_breaking_known_models(monkeypatch):
+    monkeypatch.setenv(
+        "AZURE_OPENAI_MODEL_PRICING_JSON",
+        '{"gpt-4o-mini": {"prompt": 0.0002, "completion": 0.0007}, "custom-model": {"prompt": 0.01, "completion": 0.02}}',
+    )
+    module = _reload_pricing()
+
+    overridden = module.estimate_cost("gpt-4o-mini", 1000, 1000)
+    assert abs(overridden - 0.0009) < 0.0001
+
+    preserved = module.estimate_cost("gpt-4o", 1000, 1000)
+    expected_preserved = module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o"]["prompt"] + module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o"]["completion"]
+    assert abs(preserved - expected_preserved) < 0.0001
+
+
+def test_malformed_env_falls_back_to_defaults(monkeypatch):
+    monkeypatch.setenv("AZURE_OPENAI_MODEL_PRICING_JSON", "{not valid json")
+    module = _reload_pricing()
+
+    cost = module.estimate_cost("gpt-4o-mini", 1000, 500)
+    expected = (1000 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["prompt"] + (500 / 1000) * module.MODEL_PRICING_PER_1K_TOKENS["gpt-4o-mini"]["completion"]
+    assert abs(cost - expected) < 0.0001

--- a/docs/LEARN.md
+++ b/docs/LEARN.md
@@ -179,6 +179,22 @@ Each module has its own README with step-by-step instructions.
 
 ---
 
+## 💰 Cost Tracking
+
+Every agent invocation records `prompt_tokens`, `completion_tokens`, `model_name`, and `estimated_cost_usd` on the `chat_history` table. The frontend's **Cost Insights** card in the Chat Sessions view shows per-agent and per-model cost breakdowns for the last 7 days.
+
+### Adjusting pricing
+
+Default Azure OpenAI rates live at [`backend/shared/pricing.py`](../backend/shared/pricing.py). Override per-deployment rates by setting `AZURE_OPENAI_MODEL_PRICING_JSON` in `backend/.env`:
+
+```dotenv
+AZURE_OPENAI_MODEL_PRICING_JSON={"gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006}}
+```
+
+Rates are USD per 1K tokens. Unknown models fall back to `$0.00` (cost is treated as unavailable, not free).
+
+---
+
 ## 🤝 Contributing
 
 Contributions are welcome! Here's how:

--- a/src/components/CostInsights.tsx
+++ b/src/components/CostInsights.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+import { DollarSign } from 'lucide-react';
+import { AnalyticsAPI, type CostSummary } from '../services/analyticsApi';
+
+const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#F97316'];
+
+const CostInsights: React.FC = () => {
+  const [summary, setSummary] = useState<CostSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        const data = await AnalyticsAPI.getCostSummary(7);
+        setSummary(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load cost insights');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  const pieData = useMemo(() => {
+    if (!summary) return [];
+    return summary.by_agent.slice(0, 6).map((item, index) => ({
+      ...item,
+      fill: COLORS[index % COLORS.length],
+    }));
+  }, [summary]);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <div className="flex items-center justify-center h-48">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Cost Insights (last 7 days)</h3>
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">{error}</div>
+      </div>
+    );
+  }
+
+  if (!summary || (summary.total_tokens === 0 && summary.total_cost_usd === 0)) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Cost Insights (last 7 days)</h3>
+        <p className="text-gray-500">No tokenized agent activity in the selected period.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">Cost Insights (last 7 days)</h3>
+        <DollarSign className="h-5 w-5 text-gray-400" />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="bg-blue-50 rounded-lg p-4">
+          <p className="text-sm text-blue-700">Total Cost</p>
+          <p className="text-xl font-bold text-blue-900">${summary.total_cost_usd.toFixed(6)}</p>
+        </div>
+        <div className="bg-green-50 rounded-lg p-4">
+          <p className="text-sm text-green-700">Total Tokens</p>
+          <p className="text-xl font-bold text-green-900">{summary.total_tokens.toLocaleString()}</p>
+        </div>
+        <div className="bg-yellow-50 rounded-lg p-4">
+          <p className="text-sm text-yellow-700">Conversations</p>
+          <p className="text-xl font-bold text-yellow-900">{summary.conversations}</p>
+        </div>
+        <div className="bg-purple-50 rounded-lg p-4">
+          <p className="text-sm text-purple-700">Avg Cost / Conversation</p>
+          <p className="text-xl font-bold text-purple-900">${summary.avg_cost_per_conversation.toFixed(6)}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <h4 className="text-sm font-semibold text-gray-800 mb-3">Per-Agent Breakdown</h4>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 border-b border-gray-200">
+                  <th className="py-2 pr-2">Agent</th>
+                  <th className="py-2 pr-2">Cost (USD)</th>
+                  <th className="py-2">Share</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.by_agent.map((agent) => (
+                  <tr key={agent.agent_name} className="border-b border-gray-100">
+                    <td className="py-2 pr-2 text-gray-900">{agent.agent_name}</td>
+                    <td className="py-2 pr-2 text-gray-700">${agent.cost_usd.toFixed(6)}</td>
+                    <td className="py-2 text-gray-700">{agent.percent.toFixed(2)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-semibold text-gray-800 mb-3">Cost Share by Agent</h4>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={pieData}
+                  dataKey="cost_usd"
+                  nameKey="agent_name"
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={90}
+                  innerRadius={48}
+                >
+                  {pieData.map((entry, index) => (
+                    <Cell key={`cell-${entry.agent_name}-${index}`} fill={entry.fill} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(value: number) => [`$${value.toFixed(6)}`, 'Cost']} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="grid grid-cols-2 gap-2 mt-2">
+            {pieData.map((item) => (
+              <div key={item.agent_name} className="flex items-center gap-2 text-sm text-gray-600">
+                <span className="w-3 h-3 rounded-full" style={{ backgroundColor: item.fill }}></span>
+                <span className="truncate">{item.agent_name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CostInsights;

--- a/src/components/ToolAnalytics.tsx
+++ b/src/components/ToolAnalytics.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { AnalyticsAPI } from '../services/analyticsApi';
 import type { ChatSession } from '../types/analytics';
 import { Calendar, MessageSquare, Download, Trash2, Plus } from 'lucide-react';
+import CostInsights from './CostInsights';
 
 const ChatSessions: React.FC = () => {
   const [sessions, setSessions] = useState<ChatSession[]>([]);
@@ -73,6 +74,8 @@ const ChatSessions: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      <CostInsights />
+
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-bold text-gray-900">Chat Sessions</h2>
         <button

--- a/src/services/analyticsApi.ts
+++ b/src/services/analyticsApi.ts
@@ -10,6 +10,30 @@ import type {
 // Analytics API runs on port 5002
 import { ANALYTICS_API_URL } from '../apiConfig';
 
+export interface CostSummary {
+  total_prompt_tokens: number
+  total_completion_tokens: number
+  total_tokens: number
+  total_cost_usd: number
+  conversations: number
+  avg_cost_per_conversation: number
+  by_agent: Array<{ agent_name: string; cost_usd: number; percent: number }>
+  by_model: Array<{ model_name: string; cost_usd: number }>
+}
+
+export interface TraceCost {
+  trace_id: string
+  total_cost_usd: number
+  per_step: Array<{
+    agent_name: string
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+    cost_usd: number
+    model_name: string | null
+  }>
+}
+
 export class AnalyticsAPI {
   // Chat Sessions
   static async getChatSessions(): Promise<ChatSession[]> {
@@ -144,6 +168,32 @@ export class AnalyticsAPI {
       }
     } catch (error) {
       console.error('Error clearing session:', error);
+      throw error;
+    }
+  }
+
+  static async getCostSummary(days: number = 7): Promise<CostSummary> {
+    try {
+      const response = await fetch(`${ANALYTICS_API_URL}/analytics/cost-summary?days=${days}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch cost summary: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    } catch (error) {
+      console.error('Error fetching cost summary:', error);
+      throw error;
+    }
+  }
+
+  static async getTraceCost(traceId: string): Promise<TraceCost> {
+    try {
+      const response = await fetch(`${ANALYTICS_API_URL}/analytics/trace/${encodeURIComponent(traceId)}/cost`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch trace cost: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    } catch (error) {
+      console.error('Error fetching trace cost:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

Adds per-trace token cost tracking to the banking app and a **Cost Insights** card in the Chat Sessions view. The backend already persisted `prompt_tokens`, `completion_tokens`, and `model_name` on `chat_history`; this PR layers USD cost computation, a `/api/analytics/cost-summary` aggregation endpoint, and a React card that shows per-agent and per-model breakdowns for the last 7 days.

## Why this matters

The Fabric team's post on [Operationalizing Agentic Applications on Microsoft Fabric](https://blog.fabric.microsoft.com/en/blog/operationalizing-agentic-applications-with-microsoft-fabric) calls out cost observability as a pillar of running agents responsibly. This app already captures per-call token counts end-to-end, but the Analytics tab shows content safety categories and event counts rather than dollars, so a contributor demoing the project can't answer the most natural operational question: which agent is eating the Azure OpenAI budget?

Knowing that the visualization agent is cheap while the data agent is expensive, or that gpt-4o-mini runs at a tenth of the cost of gpt-4o for the same task, is the kind of signal that turns this from a "look what's possible" sample into a reference you can reason about in production. The rest of the plumbing is already there. `chat_history` carries `total_tokens`, `completion_tokens`, `prompt_tokens`, and `model_name` per row, and `trace_id` is threaded through the full multi-agent flow. Turning that into a cost view is a straight roll-up, not a redesign.

## What changed

**Cost estimation.** A new `backend/shared/pricing.py` exposes a pure `estimate_cost(model_name, prompt_tokens, completion_tokens) -> float` helper with a default Azure OpenAI rate table (gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-35-turbo, and the three embedding models). The helper normalizes date-suffixed model names like `gpt-4o-mini-2024-11-20` back to their base, returns 0.0 on unknown models, and never raises. Enterprise agreements and regional pricing can override the table by setting `AZURE_OPENAI_MODEL_PRICING_JSON` in `backend/.env`.

**Persistence.** A nullable `estimated_cost_usd DECIMAL(10, 6)` column is added to the `ChatHistory` model and populated at every existing tokenized insertion site (in both `chat_data_model.py` and `analytics_service.py`). For fresh workspaces, the Fabric SQL artifact picks up the column automatically; for existing deployments, a small `ensure_chat_history_columns(db)` helper runs idempotent `ALTER TABLE ADD COLUMN` via SQLAlchemy's inspector, wired into both the combined-launcher and Azure-launcher startup paths right after `db.create_all()`.

**Aggregation endpoints.** `backend/cost_analytics.py` registers `GET /api/analytics/cost-summary?days=7` and `GET /api/analytics/trace/<trace_id>/cost` on the analytics service (port 5002). The queries include rows without `estimated_cost_usd` by recomputing on the fly, so the first cost view reflects history written before the migration and isn't a hard cutoff at deployment time.

**Frontend.** `src/components/CostInsights.tsx` renders four top-line metrics, a per-agent breakdown table, and a donut pie chart using the existing `recharts` and `lucide-react` dependencies. It mounts at the top of the Chat Sessions view (`ToolAnalytics.tsx`) where agent-level analytics already live. The two new typed fetchers on `AnalyticsAPI` match the style of the existing `getChatSessions` methods.

**Docs.** `docs/LEARN.md` gains a short "Cost Tracking" section that names the columns and the override env var, and the README picks up a one-line bullet under "What This App Does."

## Testing

Eleven pytest unit tests in `backend/tests/test_pricing.py` cover known and unknown models, None inputs, case-insensitive match, date-suffixed names, env overrides (happy path and malformed JSON), embedding prompt-only billing, chat prompt-only billing, zero-both-sides, and negative inputs. Run from the repo root: `python3 -m pytest backend/tests/`. The frontend `npm run build` passes. `npm run lint` adds zero new warnings; 46 pre-existing ESLint errors on `upstream/main` are unchanged.

End-to-end Fabric dogfooding was not performed - I don't have a Microsoft Fabric capacity provisioned for this. The GIF below is a Remotion-rendered simulation of the real React component with representative data; the agent names, color palette, and layout are drawn from `src/components/CostInsights.tsx` so what you see matches what the maintainer would see running the app.

## Simulated Demo

![Cost Insights simulated demo](https://raw.githubusercontent.com/mvanhorn/agentic-app-with-fabric/evidence-assets/cost-insights-demo.gif)

## Notes for reviewers

Pricing defaults were spot-checked 2026-04 against [the public Azure OpenAI pricing page](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/); users on enterprise agreements or regional pricing will want to override. The schema helper uses the SQLAlchemy inspector to check for the column before running ALTER, and logs a warning (rather than raising) on any DB error, so a failed ALTER won't cascade into banking-app startup failure. The cost endpoints return `$0.00` for rows whose model isn't in the pricing table - that's intentional (unknown model reads as "unavailable", not as "free"), and the helper's docstring calls it out. The default rates, the env var name, and the PR scope (it could be split into a backend-only and a frontend follow-up) are all open to adjustment if that fits the review cycle better.
