### PR TITLE
fix(preflight): use shell=True on Windows for az CLI resolution (#62)

### DIFF
--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -146,9 +146,14 @@ def fix_hint(m): print(f"     {C}→{X} {m}"); fixes.append(m)
 
 
 def run_cmd(cmd, check=False, capture=True):
+    # On Windows, the az CLI ships as az.cmd, which subprocess.run with a list
+    # of args cannot resolve through PATH without going through the shell.
+    # shell=True lets Windows resolve .cmd / .bat shims (see issue #62).
+    use_shell = sys.platform == "win32"
     try:
         return subprocess.run(
             cmd, capture_output=capture, text=True, check=check, timeout=120,
+            shell=use_shell,
         )
     except subprocess.TimeoutExpired as e:
         return subprocess.CompletedProcess(cmd, 124, "", str(e))


### PR DESCRIPTION
## Summary

Conditionally passes `shell=True` to `subprocess.run` in `scripts/preflight.py` on Windows so the helper can resolve `az.cmd` (and other `.cmd` / `.bat` shims) through `PATH`. Without it, every `az ...` call returned `FileNotFoundError`, which the script later surfaced as "user is not logged in" even after a successful `az login`.

Closes #62.

## Why

On Windows, the Azure CLI ships as `az.cmd`. Python's `subprocess.run` with a list of arguments doesn't walk the Windows `PATHEXT` table, so it cannot resolve `az.cmd` through `PATH` directly. The fix is to route the call through the shell only on `win32`; on macOS and Linux `az` is a real executable on `PATH`, so the existing list-form call stays in place and we don't take a shell hop unnecessarily.

The change matches the reporter's proposed fix and is the minimum patch needed to unblock Windows users.

## Test plan

- macOS / Linux: `use_shell` is `False`, behaviour is unchanged.
- Windows: `use_shell` is `True`, so `subprocess.run(["az", ...], shell=True, ...)` lets Windows resolve `az.cmd` and the subsequent Section 2 checks proceed past the login probe.